### PR TITLE
Added Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ choco install haskell-dev make
 refreshenv
 ```
 
-Then, use [do workaround](https://www.stackage.org/blog/2020/08/ghc-8-10-2-windows-workaround) to alleviate a GHC 8.10.2 issue on Windows which prevents the test suite from building correctly.
+Then, do [the workaround](https://www.stackage.org/blog/2020/08/ghc-8-10-2-windows-workaround) to alleviate a GHC 8.10.2 issue on Windows which prevents the test suite from building correctly.
 
 If you're on Linux or macOS, then the process is easy:
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ choco install haskell-dev make
 refreshenv
 ```
 
+Then, use [do workaround](https://www.stackage.org/blog/2020/08/ghc-8-10-2-windows-workaround) to alleviate a GHC 8.10.2 issue on Windows which prevents the test suite from building correctly.
+
 If you're on Linux or macOS, then the process is easy:
 
 1. Install [ghcup](https://www.haskell.org/ghcup/) and follow `ghcup`

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ section.
 
 ### Installing Haskell
 
+If you're on Windows, install the `haskell-dev` and `make` packages [using Chocolatey](https://chocolatey.org/install).
+```shell
+choco install haskell-dev make
+refreshenv
+```
+
 If you're on Linux or macOS, then the process is easy:
 
 1. Install [ghcup](https://www.haskell.org/ghcup/) and follow `ghcup`


### PR DESCRIPTION
This fixes https://github.com/kowainik/learn4haskell/issues/52

> I had to do [this](https://www.stackage.org/blog/2020/08/ghc-8-10-2-windows-workaround) to deal with a GHC 8.10.2 issue on Windows which prevented the test suite from building correctly.

The Makefile does run, but the test suite does not build for the reason above

cc @vrom911 @chshersh
