### PR TITLE
docs(Readme): Avoid unknown ghcup command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Then, do [the workaround](https://www.stackage.org/blog/2020/08/ghc-8-10-2-windo
 If you're on Linux or macOS, then the process is easy:
 
 1. Install [ghcup](https://www.haskell.org/ghcup/) and follow `ghcup`
-   instructions for successful installation.
+   instructions for successful installation (remember to restart your terminal afterwards to avoid an `unknown ghcup command` error on the next step).
 2. Install the latest version of the Haskell compiler — GHC — and the
    [Cabal](https://www.haskell.org/cabal/) build tool. After you install
    `ghcup`, it is easy to install the rest with a few commands from your


### PR DESCRIPTION
I spent the last 15 minutes trying to figure out why I got an `unknown ghcup command` when the installation went perfectly. Then I remembered I had to restart the terminal for the changes to be taken into account 😵. 

This might save a few minutes to someone else :)

cc @vrom911 @chshersh

(Note, I did not create an issue since this seemed way overkill for such a small change but I'll be happy to do so if required 🙂)
