### PR TITLE
Fix Veronika (@vrom911) personal website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Similar commands are provided for all chapters from One to Four.
 
 ## Who we are
 
-[Veronika (@vrom911)](https://vrom911.github.com/) and
+[Veronika (@vrom911)](https://vrom911.github.io/) and
 [Dmitrii (@chshersh)](https://kodimensional.dev/) are experienced Haskell developers.
 Together we drive this open source organisation —
 [Kowainik](https://kowainik.github.io/). We have a lot of open source projects


### PR DESCRIPTION
I noticed @vrom911 's website link took me to https://vrom911.github.com/ instead of https://vrom911.github.io/ so here's a quick fix
