### PR TITLE
Fix for Applicative Maybe (<*>) type signature

### DIFF
--- a/src/Chapter4.hs
+++ b/src/Chapter4.hs
@@ -400,7 +400,7 @@ instance Applicative Maybe where
     pure :: a -> Maybe a
     pure = Just
 
-    (<*>) :: Just (a -> b) -> Just a -> Just b
+    (<*>) :: Maybe (a -> b) -> Maybe a -> Maybe b
     Nothing <*> _ = Nothing
     Just f <*> x = fmap f x
 @


### PR DESCRIPTION
I believe that since Just is not a type constructor and is just a data constructor, it cannot be used in the type signature