### PR TITLE
Try to add Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -33,3 +33,4 @@ tasks:
 vscode:
   extensions:
     - haskell.haskell
+    - justusadam.language-haskell

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,6 +28,7 @@ tasks:
       ln -s /workspace/.cabal ~
     init: | 
       cabal update
+      make build
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,7 +28,6 @@ tasks:
       ln -s /workspace/.cabal ~
     init: | 
       cabal update
-      make build
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+# from https://github.com/haskell/haskell-language-server/blob/master/.gitpod.yml
+tasks:
+  - before: |
+      # Only the /workspace folder is persistent
+      export XDG_DATA_HOME=/workspace/.local/share
+      export XDG_CONFIG_HOME=/workspace/.local/config
+      export XDG_STATE_HOME=/workspace/.local/state
+      export XDG_CACHE_HOME=/workspace/.cache
+      export CABAL_DIR=/workspace/.cabal
+      export STACK_ROOT=/workspace/.stack
+
+      # install ghcup, ghc and cabal
+      export GHCUP_INSTALL_BASE_PREFIX=/workspace
+      export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+      export BOOTSTRAP_HASKELL_MINIMAL=1
+      curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+      /workspace/.ghcup/bin/ghcup install ghc --set
+      /workspace/.ghcup/bin/ghcup install cabal
+
+      # Add ghcup binaries to the PATH since VSCode does not see 'source .ghcup/env'
+      pushd /usr/local/bin
+      sudo ln -s /workspace/.ghcup/bin/* /usr/local/bin
+      popd
+
+      # Fix the Cabal dir since VSCode does not see CABAL_DIR 
+      cabal update
+      echo "Symlinking /workspace/.cabal to ~/.cabal"
+      ln -s /workspace/.cabal ~
+    init: | 
+      cabal update
+
+vscode:
+  extensions:
+    - haskell.haskell

--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ If you don't have any IDE preferences, we recommend installing
 [Haskell plugin](https://marketplace.visualstudio.com/items?itemName=haskell.haskell).
 The mentioned plugin would give you everything required to immediately start coding with Haskell.
 
+### Gitpod
+
+[Gitpod](https://www.gitpod.io/) is a VSCode-based Web IDE.
+With it, you can get a Haskell Environment out-of-the-box.
+It's free to use up to 50 hours per month.
+
+Just prepend `gitpod.io#` to your repo URL and you are ready to GO.
+
 ### How to develop
 
 The course assumes that you install Haskell tooling (GHC and Cabal), edit code

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ It's free to use up to 50 hours per month.
 
 Just prepend `gitpod.io#` to your repo URL and you are ready to go.
 It will take some time to initialize the workspace for the first time it opens.
-It only keeps changes under `/workspace`.
+It only keeps changes under `/workspace`, and it will be deleted after a period of inactivity unless it's pinned.
 
 ### How to develop
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ If you don't have any IDE preferences, we recommend installing
 The mentioned plugin would give you everything required to immediately start coding with Haskell.
 
 ### Gitpod
+
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/kowainik/learn4haskell)
+
 [Gitpod](https://www.gitpod.io/) is a VSCode-based Web IDE.
 With it, you can get a Haskell environment out-of-the-box.
 It's free to use up to 50 hours per month.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ With it, you can get a Haskell environment out-of-the-box.
 It's free to use up to 50 hours per month.
 
 Just prepend `gitpod.io#` to your repo URL and you are ready to go.
+It will take some time to initialize the workspace for the first time it opens.
 
 ### How to develop
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If you don't have any IDE preferences, we recommend installing
 The mentioned plugin would give you everything required to immediately start coding with Haskell.
 
 ### Gitpod
-
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/kowainik/learn4haskell)
 [Gitpod](https://www.gitpod.io/) is a VSCode-based Web IDE.
 With it, you can get a Haskell environment out-of-the-box.
 It's free to use up to 50 hours per month.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ The mentioned plugin would give you everything required to immediately start cod
 ### Gitpod
 
 [Gitpod](https://www.gitpod.io/) is a VSCode-based Web IDE.
-With it, you can get a Haskell Environment out-of-the-box.
+With it, you can get a Haskell environment out-of-the-box.
 It's free to use up to 50 hours per month.
 
-Just prepend `gitpod.io#` to your repo URL and you are ready to GO.
+Just prepend `gitpod.io#` to your repo URL and you are ready to go.
 
 ### How to develop
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ It's free to use up to 50 hours per month.
 
 Just prepend `gitpod.io#` to your repo URL and you are ready to go.
 It will take some time to initialize the workspace for the first time it opens.
+It only keeps changes under `/workspace`.
 
 ### How to develop
 


### PR DESCRIPTION
Ideally this would be an environment that needn't manually install ghc and cabal, which is simpler for beginners.

Though I'm new to both Haskell and Gitpod, so I open this as a draft for now to see if it needs some improvements. At least the new content in README should be polished, because I'm not an English-native speaker.

---

Another option is using this dockerfile and yml, which is created by myself:

```dockerfile
FROM gitpod/workspace-base

RUN echo "deb http://downloads.haskell.org/debian buster main" | sudo tee -a /etc/apt/sources.list \
    && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA3CBA3FFE22B574 \
    && sudo apt-get update && sudo apt-get install ghc-8.10.4 cabal-install-3.2 -y
ENV PATH $PATH:/opt/ghc/bin
```

```yml
image:
  file: .gitpod.Dockerfile
tasks:
  - init: |
      cabal update
      make build
vscode:
  extensions:
    - haskell.haskell
    - justusadam.language-haskell
```

---

I also tried other options, but they are not working. Here is the record for myself.

<details>
<summary>image: haskell:8</summary>

```yml
# https://github.com/haskell/docker-haskell
image: haskell:8

vscode:
  extensions:
    - haskell.haskell
```

VSC's haskell extension will show `Project requires GHC but it isn't installed` in empty project.

```
[client][ERROR] Error executing '/home/gitpod/.gitpod-code/User/globalStorage/haskell.haskell/haskell-language-server-wrapper-1.4.0-linux --project-ghc-version' with error code 1
[client][ERROR] stderr: No 'hie.yaml' found. Try to discover the project type!
Cradle requires ghc but couldn't find it
Cradle {cradleRootDir = "/workspace/hspod", cradleOptsProg = CradleAction: Default}
```

In this project, it will show `Couldn't figure out what GHC version the project is using`

```
[client][ERROR] Error executing '/home/gitpod/.gitpod-code/User/globalStorage/haskell.haskell/haskell-language-server-wrapper-1.4.0-linux --project-ghc-version' with error code 1
[client][ERROR] stderr: No 'hie.yaml' found. Try to discover the project type!
Failed to get project GHC version:CradleError {cradleErrorDependencies = [], cradleErrorExitCode = ExitFailure 1, cradleErrorStderr = ["Error when calling cabal --builddir=/home/gitpod/.cache/hie-bios/dist-learn4haskell-72472cabe140c207d0a42c08ba7b1c46 v2-exec --with-compiler /home/gitpod/.cache/hie-bios/wrapper-13a09b18ea883dd377d59db5e821a86b ghc -v0 -- --numeric-version","","cabal: The program 'ghc' version >=7.0.1 is required but the version of
/home/gitpod/.cache/hie-bios/wrapper-13a09b18ea883dd377d59db5e821a86b could
not be determined.
"]}
```

But use `/home/gitpod/.gitpod-code/User/globalStorage/haskell.haskell/haskell-language-server-wrapper-1.4.0-linux --project-ghc-version` in terminal will output `8.10.7`.

Now I find for one console, the PATH contains `/opt/ghc/8.10.7/bin`, but new console doesn't.
With `echo "export PATH=$PATH:$(ls /opt/ghc/*/bin -d)" >> ~/.bashrc`, new console can use ghc, but it still reports the same error. I then tried `gp env PATH="$(ls /opt/ghc/*/bin -d):$PATH"` or `ENV PATH /opt/ghc/8.10.7/bin:$PATH` but it's the same.

I think it may be cause by not using  gitpod/workspace-base. The environment is too thin, it even doesn't have `ls` and `sudo`
</details>

<details>
<summary>gitpod-io/template-haskell</summary>

Gitpod's official haskell yml: https://github.com/gitpod-io/template-haskell/blob/main/.gitpod.yml

Basically it's doing `apt install haskell-platform`. And it will install 8.9.5, which is incompatible with this project.

```
[client][ERROR] Error executing '/home/gitpod/.gitpod-code/User/globalStorage/haskell.haskell/haskell-language-server-wrapper-1.4.0-linux --project-ghc-version' with error code 1
[client][ERROR] stderr: No 'hie.yaml' found. Try to discover the project type!
Failed to get project GHC version:CradleError {cradleErrorDependencies = [], cradleErrorExitCode = ExitFailure 1, cradleErrorStderr = ["Error when calling cabal --builddir=/home/gitpod/.cache/hie-bios/dist-learn4haskell-72472cabe140c207d0a42c08ba7b1c46 v2-exec --with-compiler /home/gitpod/.cache/hie-bios/wrapper-13a09b18ea883dd377d59db5e821a86b ghc -v0 -- --numeric-version","","cabal: Could not resolve dependencies:\n[__0] trying: learn4haskell-0.0.0.0 (user goal)\n[__1] next goal: base (dependency of learn4haskell)\n[__1] rejecting: base-4.12.0.0/installed-4.1... (conflict: learn4haskell =>\nbase^>=4.14.0.0)\n[__1] rejecting: base-4.15.0.0, base-4.14.3.0, base-4.14.2.0, base-4.14.1.0,\nbase-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0, base-4.11.0.0,\nbase-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0, base-4.8.2.0,\nbase-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1, base-4.7.0.0,\nbase-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0, base-4.4.1.0,\nbase-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2, base-4.2.0.1,\nbase-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2, base-3.0.3.1\n(constraint from non-upgradeable package requires installed instance)\n[__1] fail (backjumping, conflict set: base, learn4haskell)\nAfter searching the rest of the dependency tree exhaustively, these were the\ngoals I've had most trouble fulfilling: base, learn4haskell\n\n"]}
```
</details>

<details>
<summary>GitHub Codespaces</summary>

* https://github.com/microsoft/vscode-dev-containers/tree/main/containers/haskell it works. But `common-debian.sh` seems too large
* https://github.com/vzarytovskii/haskell-dev-env didn't try
* It isn't open for everyone. Only those who are in beta testing can use Codespace. Otherwise it's not free
</details>