### PR TITLE
CI: use major version and add workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
         ghc: ["8.10.4"]
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1.2.6
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
@@ -42,15 +42,15 @@ jobs:
         cabal: ["3.2"]
         ghc: ["8.10.4"]
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1.2.6
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
@@ -77,15 +77,15 @@ jobs:
         cabal: ["3.2"]
         ghc: ["8.10.4"]
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1.2.6
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
@@ -112,15 +112,15 @@ jobs:
         cabal: ["3.2"]
         ghc: ["8.10.4"]
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1.2.6
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
@@ -138,15 +138,15 @@ jobs:
         cabal: ["3.2"]
         ghc: ["8.10.4"]
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1.2.6
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     types: [synchronize, opened, reopened]
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
I think there is no need to lock minor versions.

workflow_dispatch will add a button on Actions tab to let users run the CI manually.